### PR TITLE
Docs: added links to Python aidatlu software

### DIFF
--- a/docs/satellites/external_satellites.json
+++ b/docs/satellites/external_satellites.json
@@ -9,6 +9,11 @@
       "name": "CMS Pixel / pxar",
       "readme": "https://raw.githubusercontent.com/simonspa/pxar/refs/heads/cnstln-testbeam-extend/constellation/README.md",
       "website": "https://github.com/simonspa/pxar/tree/cnstln-testbeam-extend"
+    },
+    {
+      "name": "AIDA-2020 TLU / aidatlu",
+      "readme": "https://github.com/SiLab-Bonn/aidatlu/blob/main/aidatlu/constellation/README.md",
+      "website": "https://github.com/SiLab-Bonn/aidatlu"
     }
   ]
 }


### PR DESCRIPTION
This MR adds the documentation of the Python based AIDA-2020 TLU software and its `Satellite` to `Constellation`.
The software allows easy configuration and usage of the AIDA-TLU.