### PR TITLE
Added Satellite for ANEMONE

### DIFF
--- a/docs/satellites/external_satellites.json
+++ b/docs/satellites/external_satellites.json
@@ -24,6 +24,11 @@
       "name": "AMIModel1700LLI",
       "readme": "https://gitlab.desy.de/madmax/hamburg/amimodel1700lli-satellite/-/raw/main/README.md",
       "website": "https://gitlab.desy.de/madmax/hamburg/amimodel1700lli-satellite"
+    },
+    {
+      "name": "Eudet-Telescope with MMC3 / pymosa",
+      "readme": "https://raw.githubusercontent.com/SiLab-Bonn/pymosa/refs/heads/master/pymosa/constellation/README.md",
+      "website": "https://github.com/SiLab-Bonn/pymosa"
     }
   ]
 }


### PR DESCRIPTION
Added an satellite for an Eudet-type beam telescope with MMC3 readout. 
I am not sure this is so relevant for many other people, but the Satellite works quite nicely. We already used this satellite for the BL4S event. In the time since the event I added a README and cleaned everything up.
