### PR TITLE
Allow python heartbeatchecker to also track the last status message sent

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,3 +23,4 @@ The following authors, in alphabetical order, have developed or contributed to C
 * Annika Vauth, Universität Hamburg, [annika.vauth](https://gitlab.desy.de/annika.vauth)
 * Håkan Wennlöf, Deutsches Elektronen-Synchrotron DESY, [hwennlof](https://gitlab.desy.de/hwennlof)
 * David Leppla-Weber, Deutsches Elektronen-Synchrotron DESY, [david.leppla-weber](https://gitlab.desy.de/david.leppla-weber)
+* Simon Koch, CERN, [sfkoch](https://gitlab.cern.ch/sfkoch)

--- a/python/constellation/core/heartbeatchecker.py
+++ b/python/constellation/core/heartbeatchecker.py
@@ -34,6 +34,7 @@ class HeartbeatState:
         self.last_refresh = time.monotonic()
         self.last_statechange = datetime(2000, 1, 1)
         self.state = SatelliteState.DEAD
+        self.status: str = ""
         self.failed: threading.Event = evt
 
     def refresh(self, ts: datetime | None = None) -> None:
@@ -180,6 +181,11 @@ class HeartbeatChecker(BaseSatelliteFrame):
         return res
 
     @property
+    def heartbeat_status(self) -> dict[str, str]:
+        """Return a dictionary of the last status message received from each Satellite."""
+        return {hb.name: hb.status for hb in self._remote_heartbeat_states.values()}
+
+    @property
     def heartbeat_state_changes(self) -> dict[str, datetime]:
         """Return a dictionary of the times of the last state changes."""
         res = {}
@@ -221,6 +227,8 @@ class HeartbeatChecker(BaseSatelliteFrame):
                 )
                 hb.interval = interval
                 hb.role = CHPRole.from_flags(flags)
+                if status:
+                    hb.status = status
                 # refresh lives
                 if hb.lives != self.HB_INIT_LIVES:
                     self.log_chp.trace(


### PR DESCRIPTION
The C++ interfaces already allow controllers to natively track the last message received from each Satellite via the heartbeat system (see the MissionControl panel as an example). This MR adds parity for python-based controllers, allowing these to easily query status messages for each Satellite and record or display these as desired.